### PR TITLE
Cifuzz dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 ARG CIFUZZ_TOKEN
 
 RUN apt-get update && \
-    apt-get install -y bison libssl-dev libevent-dev openssl curl cmake clang build-essential llvm lldb git pkg-config ninja-build zip unzip tar yacc lcov vim
+    apt-get install -y bison libssl-dev libevent-dev openssl curl clang build-essential llvm lldb git pkg-config ninja-build zip unzip tar yacc lcov vim
+
+RUN apt-get install -y software-properties-common lsb-release ca-certificates apt-transport-https gnupg curl
+RUN curl -s https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dearmor -o /usr/share/keyrings/kitware-archive-keyring.gpg  && \
+    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/kitware.list && \
+    apt-get update && \
+    apt-get install -y cmake
 
 RUN sh -c "$(curl -fsSL http://downloads.code-intelligence.com/assets/install-cifuzz.sh)" $CIFUZZ_TOKEN
 

--- a/regress/cifuzz/CMakeLists.txt
+++ b/regress/cifuzz/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(CIFuzzTestHelpers PRIVATE
     cifuzz_create_iked_env.c
     cifuzz_destroy_iked_env_aux.c
     cifuzz_destroy_iked_env.c
+    fuzzer_utils/ca_utils.c
 )
 #
 # Mimic vroute branching from iked subproject.
@@ -80,6 +81,8 @@ set(fuzzers
     parse_config_fuzzer
     vroute_getaddr_fuzzer
 )
+
 foreach(fuzzer IN LISTS fuzzers)
-    AddFuzzTarget(TARGET_NAME ${fuzzer} SOURCES ${fuzzer}.c DEPENDENCIES CIFuzzTestHelpers iked-shared compat)
+    AddFuzzTarget(TARGET_NAME ${fuzzer} SOURCES ${fuzzer}.c  DEPENDENCIES CIFuzzTestHelpers iked-shared compat)
+    set_target_properties(${fuzzer} PROPERTIES LINK_FLAGS "-Wl,--wrap=config_setkeys -Wl,--wrap=event_add")
 endforeach()

--- a/regress/cifuzz/ca_dispatch_ikev2_fuzzer.c
+++ b/regress/cifuzz/ca_dispatch_ikev2_fuzzer.c
@@ -8,8 +8,9 @@
 #include "iked.h"
 #include "cifuzz_iked_env.h"
 
-extern int
-ca_reload(struct iked *env);
+#include "mocks/mocks.h"
+
+#include "fuzzer_utils/ca_utils.c"
 
 int LLVMFuzzerInitialize(int *argc, char ***argv)
 {
@@ -19,18 +20,21 @@ int LLVMFuzzerInitialize(int *argc, char ***argv)
         cifuzz_bundled_config_embedded_blob(),
         cifuzz_bundled_config_embedded_blob_size()
     );
+
+    copy_all_files();
     return 0;
+
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *__data, size_t __size)
 {
     FuzzDataProvider provider = FuzzDataConstruct(__data, __size);
 
-    /* need to set global variable */
     struct iked *env = cifuzz_create_iked_env();
     iked_env = env;
     cifuzz_create_iked_env_aux(env);
-
+    config_setkeys(env);
+    ca_reset(NULL);
     struct imsg imsg = {
         .hdr = {
             .type = FuzzDataReadUint32(&provider),
@@ -52,9 +56,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *__data, size_t __size)
     ca_dispatch_ikev2(-1, NULL, &imsg);
 
     free(payload);
-
     cifuzz_destroy_iked_env_aux(env);
     cifuzz_destroy_iked_env(env);
+    event_base_free(NULL);
     iked_env = NULL;
 
     return 0;

--- a/regress/cifuzz/ca_dispatch_parent_fuzzer.c
+++ b/regress/cifuzz/ca_dispatch_parent_fuzzer.c
@@ -12,6 +12,10 @@
 #include "fuzzdataprovider.h"
 #include "iked.h"
 #include "cifuzz_iked_env.h"
+#include "ca.h"
+#include "mocks/mocks.h"
+#include "fuzzer_utils/ca_utils.c"
+
 
 struct cifuzz_IMSG_CTL_RESET_payload
 {
@@ -93,6 +97,8 @@ int LLVMFuzzerInitialize(int *argc, char ***argv)
         cifuzz_bundled_config_embedded_blob(),
         cifuzz_bundled_config_embedded_blob_size()
     );
+
+    copy_all_files();
     return 0;
 }
 
@@ -104,6 +110,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *__data, size_t __size)
     struct iked *env = cifuzz_create_iked_env();
     iked_env = env;
     cifuzz_create_iked_env_aux(env);
+    config_setkeys(env);
+    ca_reset(NULL);
 
     struct imsg imsg = {
         .hdr = {
@@ -130,6 +138,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *__data, size_t __size)
 
     cifuzz_destroy_iked_env_aux(env);
     cifuzz_destroy_iked_env(env);
+    event_base_free(NULL);
     iked_env = NULL;
 
     return 0;

--- a/regress/cifuzz/cifuzz_create_iked_env.c
+++ b/regress/cifuzz/cifuzz_create_iked_env.c
@@ -143,7 +143,6 @@ struct iked *cifuzz_create_iked_env()
 
     ps->ps_noaction = 1;
     ps->ps_instance = 0;
-
     /*
      * skip all libevent invokations and signal setup
      */
@@ -153,9 +152,12 @@ struct iked *cifuzz_create_iked_env()
 
     setproctitle("parent");
     log_procinit("parent");
-
+#endif
+	// We want to call event_init to initialize the event base.
+	// leaving it uninitialized my cause SEGV
     event_init();
 
+#if 0
     signal_set(&ps->ps_evsigint, SIGINT, parent_sig_handler, ps);
     signal_set(&ps->ps_evsigterm, SIGTERM, parent_sig_handler, ps);
     signal_set(&ps->ps_evsigchld, SIGCHLD, parent_sig_handler, ps);

--- a/regress/cifuzz/fuzzer_utils/ca_utils.c
+++ b/regress/cifuzz/fuzzer_utils/ca_utils.c
@@ -1,0 +1,85 @@
+#include "ca_utils.h"
+
+#define BUFFER_SIZE 1024
+#define SOURCE_DIR "/etc/iked/"
+
+void copy_file(const char *src_path, const char *dest_path) {
+    int src_fd = open(src_path, O_RDONLY);
+    if (src_fd == -1) {
+        perror("Failed to open source file");
+        return;
+    }
+
+    int dest_fd = open(dest_path, O_WRONLY | O_CREAT | O_TRUNC,
+                       S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    if (dest_fd == -1) {
+        perror("Failed to open destination file");
+        close(src_fd);
+        return;
+    }
+
+    char buffer[BUFFER_SIZE];
+    ssize_t bytes_read, bytes_written;
+
+    while ((bytes_read = read(src_fd, buffer, BUFFER_SIZE)) > 0) {
+        bytes_written = write(dest_fd, buffer, bytes_read);
+        if (bytes_written != bytes_read) {
+            perror("Failed to write to destination file");
+            close(src_fd);
+            close(dest_fd);
+            return;
+        }
+    }
+
+    if (bytes_read == -1) {
+        perror("Failed to read from source file");
+    }
+
+    close(src_fd);
+    close(dest_fd);
+}
+
+void copy_directory(const char *src_dir, const char *dest_dir) {
+    struct dirent *entry;
+    struct stat statbuf;
+    char src_path[PATH_MAX];
+    char dest_path[PATH_MAX];
+
+    DIR *dir = opendir(src_dir);
+    if (dir == NULL) {
+        perror("Failed to open source directory");
+        return;
+    }
+
+    if (mkdir(dest_dir, 0755) == -1 && errno != EEXIST) {
+        perror("Failed to create destination directory");
+        closedir(dir);
+        return;
+    }
+
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 ||
+            strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+
+        snprintf(src_path, sizeof(src_path), "%s/%s", src_dir, entry->d_name);
+        snprintf(dest_path, sizeof(dest_path), "%s/%s", dest_dir,
+                 entry->d_name);
+
+        if (stat(src_path, &statbuf) == -1) {
+            perror("Failed to get file status");
+            continue;
+        }
+
+        if (S_ISDIR(statbuf.st_mode)) {
+            copy_directory(src_path, dest_path);
+        } else if (S_ISREG(statbuf.st_mode)) {
+            copy_file(src_path, dest_path);
+        }
+    }
+
+    closedir(dir);
+}
+
+void copy_all_files() { copy_directory(SOURCE_DIR, "."); }

--- a/regress/cifuzz/fuzzer_utils/ca_utils.h
+++ b/regress/cifuzz/fuzzer_utils/ca_utils.h
@@ -1,0 +1,37 @@
+#ifndef CA_UTILS_H
+#define CA_UTILS_H
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+/*
+    This header provides utility functions for ca fuzzers.
+    ca process normally runs in chroot jail on /etc/iked/
+    This is not optimal to do during fuzzing for
+    many reasons (overhead, chroot pivot, complexity etc.).
+    Instead files and certificates from /etc/iked/ are copied to current
+   directory
+    (/openiked-portable/) in the fuzzing container.
+    This solution while not the cleanest,
+    allows us to effectively load the keys without using chroot jails.
+*/
+
+#define BUFFER_SIZE 1024
+#define SOURCE_DIR "/etc/iked/"
+
+// copies every file from source to destination
+void copy_file(const char *src_path, const char *dest_path);
+
+// copies every directory (files included) from source to destination
+void copy_directory(const char *src_dir, const char *dest_dir);
+
+// copies everything
+void copy_all_files();
+
+#endif

--- a/regress/cifuzz/ikev2_dispatch_cert_fuzzer.c
+++ b/regress/cifuzz/ikev2_dispatch_cert_fuzzer.c
@@ -6,6 +6,7 @@
 #include "fuzzdataprovider.h"
 #include "iked.h"
 #include "cifuzz_iked_env.h"
+#include "mocks/mocks.h"
 
 int LLVMFuzzerInitialize(int *argc, char ***argv)
 {
@@ -132,6 +133,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *__data, size_t __size)
 
     cifuzz_destroy_iked_env_aux(env);
     cifuzz_destroy_iked_env(env);
+    event_base_free(NULL);
     iked_env = NULL;
 
     return 0;

--- a/regress/cifuzz/ikev2_dispatch_control_fuzzer.c
+++ b/regress/cifuzz/ikev2_dispatch_control_fuzzer.c
@@ -6,6 +6,7 @@
 #include "fuzzdataprovider.h"
 #include "iked.h"
 #include "cifuzz_iked_env.h"
+#include "mocks/mocks.h"
 
 /*
  * not exported symbol from

--- a/regress/cifuzz/ikev2_dispatch_parent_fuzzer.c
+++ b/regress/cifuzz/ikev2_dispatch_parent_fuzzer.c
@@ -12,6 +12,7 @@
 #include "fuzzdataprovider.h"
 #include "iked.h"
 #include "cifuzz_iked_env.h"
+#include "mocks/mocks.h"
 
 struct cifuzz_IMSG_CTL_RESET_payload
 {
@@ -194,6 +195,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *__data, size_t __size)
 
     cifuzz_destroy_iked_env_aux(env);
     cifuzz_destroy_iked_env(env);
+    event_base_free(NULL);
     iked_env = NULL;
 
     return 0;

--- a/regress/cifuzz/mocks/config_mocks.h
+++ b/regress/cifuzz/mocks/config_mocks.h
@@ -1,0 +1,111 @@
+#ifndef CONFIG_MOCKS_H
+#define CONFIG_MOCKS_H
+
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <string.h>
+#include "iked.h"
+#include "ikev2.h"
+
+/*
+This function is called by configure parent, after spawning the ca process. If
+it fails, iked exits. To simulate this in the fuzzing environment we are gonna
+call it as part of the env setup. The difference is that we are NOT going to use
+events to set up the env structure, like the original function does.
+*/
+int __wrap_config_setkeys(struct iked *env) {
+#ifdef DEBUG
+    printf("Called mocked config_setkeys.");
+#endif
+
+    FILE *fp = NULL;
+    EVP_PKEY *key = NULL;
+    struct iked_id privkey;
+    struct iked_id pubkey;
+    struct iovec iov[2];
+    int ret = -1;
+
+    struct iked_id privkey_copy;
+    struct iked_id pubkey_copy;
+    memset(&privkey, 0, sizeof(privkey));
+    memset(&pubkey, 0, sizeof(pubkey));
+    memset(&privkey_copy, 0, sizeof(privkey_copy));
+    memset(&pubkey_copy, 0, sizeof(pubkey_copy));
+
+    if ((fp = fopen(IKED_PRIVKEY, "r")) == NULL) {
+        log_warn("%s: failed to open private key", __func__);
+        goto done;
+    }
+
+    if ((key = PEM_read_PrivateKey(fp, NULL, NULL, NULL)) == NULL) {
+        log_warnx("%s: failed to read private key", __func__);
+        goto done;
+    }
+
+    if (ca_privkey_serialize(key, &privkey) != 0) {
+        log_warnx("%s: failed to serialize private key", __func__);
+        goto done;
+    }
+    if (ca_pubkey_serialize(key, &pubkey) != 0) {
+        log_warnx("%s: failed to serialize public key", __func__);
+        goto done;
+    }
+
+    // Make copies for private and public keys,
+    // these will be passed to ca_getkey
+    // we could directly pass ca_pubkey/ca_privkey
+    // but kept the copies for better debugging
+    if (ca_privkey_serialize(key, &privkey_copy) != 0) {
+        log_warnx("%s: failed to serialize private key copy", __func__);
+        goto done;
+    }
+    if (ca_pubkey_serialize(key, &pubkey_copy) != 0) {
+        log_warnx("%s: failed to serialize public key copy", __func__);
+        goto done;
+    }
+
+    ca_getkey(NULL, &privkey_copy, IMSG_PRIVKEY);
+    ca_getkey(NULL, &pubkey_copy, IMSG_PUBKEY);
+
+    /*
+    The code bellow composes an event to write the keys
+    via another process.
+    We written the keys into env via the ca_getkey function
+    to simplify the setup.
+    */
+
+    /*
+    iov[0].iov_base = &privkey;
+    iov[0].iov_len = sizeof(privkey);
+    iov[1].iov_base = ibuf_data(privkey.id_buf);
+    iov[1].iov_len = ibuf_size(privkey.id_buf);
+
+    if (proc_composev(&env->sc_ps, PROC_CERT, IMSG_PRIVKEY, iov, 2) == -1) {
+            log_warnx("%s: failed to send private key", __func__);
+            goto done;
+    }
+
+    iov[0].iov_base = &pubkey;
+    iov[0].iov_len = sizeof(pubkey);
+    iov[1].iov_base = ibuf_data(pubkey.id_buf);
+    iov[1].iov_len = ibuf_size(pubkey.id_buf);
+
+    if (proc_composev(&env->sc_ps, PROC_CERT, IMSG_PUBKEY, iov, 2) == -1) {
+            log_warnx("%s: failed to send public key", __func__);
+            goto done;
+    }
+
+    */
+    ret = 0;
+done:
+    if (fp != NULL)
+        fclose(fp);
+
+    ibuf_free(pubkey.id_buf);
+    ibuf_free(privkey.id_buf);
+    EVP_PKEY_free(key);
+
+    return (ret);
+}
+
+#endif // CONFIG_MOCKS_H

--- a/regress/cifuzz/mocks/mocks.h
+++ b/regress/cifuzz/mocks/mocks.h
@@ -1,0 +1,6 @@
+#ifndef MOCKS_H
+
+#include "config_mocks.h"
+#include "timer_mocks.h"
+
+#endif

--- a/regress/cifuzz/mocks/timer_mocks.h
+++ b/regress/cifuzz/mocks/timer_mocks.h
@@ -1,0 +1,35 @@
+#ifndef TIMER_MOCKS_H
+#define TIMER_MOCKS_H
+
+#include "iked.h"
+
+const int MAX_EVENT_RECURSION_DEPTH = 10;
+
+/*
+Here we want to immediately call the callback function
+in blocking mode.
+Recursion depth is introduced to limit recursive event_add calls
+*/
+int __wrap_event_add(struct event *ev, const struct timeval *timeout) {
+#ifdef DEBUG
+    printf("Called mocked event_add.\n")
+#endif
+
+        static int current_recursion_depth = 0;
+
+    if (ev && ev->ev_evcallback.evcb_cb_union.evcb_callback) {
+        if (current_recursion_depth < MAX_EVENT_RECURSION_DEPTH) {
+            current_recursion_depth++;
+            ev->ev_evcallback.evcb_cb_union.evcb_callback(
+                ev->ev_fd, ev->ev_events, ev->ev_evcallback.evcb_arg);
+            current_recursion_depth--;
+
+        } else {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+#endif

--- a/regress/cifuzz/oscp_connect_fuzzer.c
+++ b/regress/cifuzz/oscp_connect_fuzzer.c
@@ -9,6 +9,7 @@
 #include "fuzzdataprovider.h"
 #include "iked.h"
 #include "cifuzz_iked_env.h"
+#include "mocks/mocks.h"
 
 struct cifuzz_ocsp_connect_payload
 {
@@ -77,6 +78,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *__data, size_t __size)
 
     cifuzz_destroy_iked_env_aux(env);
     cifuzz_destroy_iked_env(env);
+    event_base_free(NULL);
     iked_env = NULL;
 
     return 0;

--- a/regress/cifuzz/parse_config_fuzzer.c
+++ b/regress/cifuzz/parse_config_fuzzer.c
@@ -9,6 +9,7 @@
 #include "fuzzdataprovider.h"
 #include "iked.h"
 #include "cifuzz_iked_env.h"
+#include "mocks/mocks.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *__data, size_t __size)
 {
@@ -53,6 +54,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *__data, size_t __size)
 
     cifuzz_destroy_iked_env_aux(env);
     cifuzz_destroy_iked_env(env);
+    event_base_free(NULL);
     iked_env = NULL;
 
     return 0;

--- a/regress/cifuzz/vroute_getaddr_fuzzer.c
+++ b/regress/cifuzz/vroute_getaddr_fuzzer.c
@@ -13,6 +13,7 @@
 #include "fuzzdataprovider.h"
 #include "iked.h"
 #include "cifuzz_iked_env.h"
+#include "mocks/mocks.h"
 
 int LLVMFuzzerInitialize(int *argc, char ***argv)
 {
@@ -61,6 +62,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *__data, size_t __size)
 
     cifuzz_destroy_iked_env_aux(env);
     cifuzz_destroy_iked_env(env);
+    event_base_free(NULL);
     iked_env = NULL;
 
     return 0;


### PR DESCRIPTION
## What changes this PR introduces

### Docker image modification
- The base docker image was changed to ubuntu 2204 as it is more stable and cross compatible due to stable
glibc version.

### Mock and utility introduction
- Added some mocks for `libevent` functions to execute events in blocking mode during fuzzing.
- Added some utilities for ca fuzzers to copy certificates from `/etc/iked/` to current directory because normally, the ca process runs in a chroot jail in `/etc/iked` and this is not optimal to do during fuzzing.

### Fuzzer and env update
- Updated fuzzers to use the mocks and ca fuzzers to use key setup and ca configuration functions
- Updated env creation and cleanup by initializing the event creation and destruction to avoid false positive segfault crashes.